### PR TITLE
Adds support for private ip only AWS instances

### DIFF
--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -407,6 +407,10 @@ def aws_host(resource, module_name):
         attrs['ansible_ssh_user'] = raw_attrs['tags.sshUser']
     if 'tags.sshPrivateIp' in raw_attrs:
         attrs['ansible_ssh_host'] = raw_attrs['private_ip']
+    if not attrs['ansible_ssh_host']:
+        attrs['ansible_ssh_host'] = raw_attrs['private_ip']
+    if 'tags.sshCommonArgs' in raw_attrs and raw_attrs['tags.sshCommonArgs']:
+        attrs['ansible_ssh_common_args'] = raw_attrs['tags.sshCommonArgs']
 
     # attrs specific to Mantl
     attrs.update({

--- a/terraform/aws/elb/main.tf
+++ b/terraform/aws/elb/main.tf
@@ -17,9 +17,9 @@ resource "aws_elb" "mantl-elb" {
   idle_timeout = 400
   connection_draining = true
   connection_draining_timeout = 400
-  subnets = ["${split(\",\", var.subnets)}"]
-  security_groups = ["${split(\",\", var.security_groups)}"]
-  instances = ["${split(\",\", var.instances)}"]
+  subnets = ["${split(",", var.subnets)}"]
+  security_groups = ["${split(",", var.security_groups)}"]
+  instances = ["${split(",", var.instances)}"]
 
   listener {
     instance_port = 80

--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -63,17 +63,17 @@ resource "aws_volume_attachment" "instance-lvm-attachment" {
 
 
 output "hostname_list" {
-  value = "${join(\",\", aws_instance.instance.*.tags.Name)}"
+  value = "${join(",", aws_instance.instance.*.tags.Name)}"
 }
 
 output "ec2_ids" {
-  value = "${join(\",\", aws_instance.instance.*.id)}"
+  value = "${join(",", aws_instance.instance.*.id)}"
 }
 
 output "ec2_ips" {
-  value = "${join(\",\", aws_instance.instance.*.public_ip)}"
+  value = "${join(",", aws_instance.instance.*.public_ip)}"
 }
 
 output "ec2_private_ips" {
-  value = "${join(\",\", aws_instance.instance.*.private_ip)}"
+  value = "${join(",", aws_instance.instance.*.private_ip)}"
 }

--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -13,6 +13,7 @@ variable "source_ami" {}
 variable "security_group_ids" {}
 variable "vpc_subnet_ids" {}
 variable "ssh_username" {default = "centos"}
+variable "assign_public_ip_address" {default = true}
 
 
 resource "aws_ebs_volume" "ebs" {
@@ -33,8 +34,8 @@ resource "aws_instance" "instance" {
   count = "${var.count}"
   vpc_security_group_ids = [ "${split(",", var.security_group_ids)}"]
   key_name = "${var.ssh_key_pair}"
-  associate_public_ip_address = true
-  subnet_id = "${element(split(",", var.vpc_subnet_ids), count.index)}" 
+  associate_public_ip_address = "${var.assign_public_ip_address}"
+  subnet_id = "${element(split(",", var.vpc_subnet_ids), count.index)}"
   iam_instance_profile = "${var.iam_profile}"
   root_block_device {
     delete_on_termination = true

--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -73,3 +73,7 @@ output "ec2_ids" {
 output "ec2_ips" {
   value = "${join(\",\", aws_instance.instance.*.public_ip)}"
 }
+
+output "ec2_private_ips" {
+  value = "${join(\",\", aws_instance.instance.*.private_ip)}"
+}


### PR DESCRIPTION
When deploying to AWS and using an ELB it is possible for all Mantl instance roles to live in a private subnet. In this deployment scenario public ip addresses are not required (and worse can be confusing to users looking at these instances). 

This PR adds a tfvar to the `aws/instance` module so that users of this module (namely `aws.tf`) can specify a private subnet and prevent the assigning of a public ip address should one decide to deploy in this configuration. Additionally the private ips for the instance are output for use by other terraform resources. 

This change is backwards compatible for all existing aws.tf customizations.
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes

I am happy to address relevant documentation changes if someone can help me identify them. I searched for `private` on docs.mantl.io and did not find any results. 
