### PR TITLE
mantldata volume + external disk for mesos, kafka, and elasticsearch

### DIFF
--- a/roles/disk/README.rst
+++ b/roles/disk/README.rst
@@ -1,0 +1,9 @@
+Disk
+======
+
+.. versionadded:: 1.3
+
+The disks role simply configures a ``mantldata`` logical volume and allocates
+the remainder (by default) of the mantl physical volume to ``/mnt/mantldata``.
+This is a good location to use for host-level storage and is used by addons like
+Kafka and Elasticsearch (by default).

--- a/roles/disk/defaults/main.yml
+++ b/roles/disk/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+mantl_data_lvm_data_volume_size: 100%FREE

--- a/roles/disk/meta/main.yml
+++ b/roles/disk/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: lvm

--- a/roles/disk/tasks/main.yml
+++ b/roles/disk/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: configure lvm for mantl data
+  sudo: yes
+  template:
+    src: 90-mantl-data-volume.conf.j2
+    dest: /etc/mantl/filesystems.d/90-mantl-data-volume.conf
+    mode: 0644
+  when: lvm_physical_device != ""
+  tags:
+    - disk
+
+- name: process with mantl storage setup
+  sudo: yes
+  when: lvm_physical_device != ""
+  shell: "/usr/bin/mantl-storage-setup"
+
+- name: enable mounts
+  sudo: yes
+  service:
+    name: mnt-mantldata.mount
+    state: started
+    enabled: yes
+  when: lvm_physical_device != ""
+  tags:
+    - disk
+
+- name: create /mnt/mantldata for non-lvm platforms
+  sudo: yes
+  shell: mkdir -p /mnt/mantldata
+  when: lvm_physical_device == ""
+  tags:
+    - disk

--- a/roles/disk/templates/90-mantl-data-volume.conf.j2
+++ b/roles/disk/templates/90-mantl-data-volume.conf.j2
@@ -1,0 +1,9 @@
+[volume:mantldata]
+group = mantl
+volume = mantldata
+size = {{ mantl_data_lvm_data_volume_size }}
+
+[filesystem:mantldata]
+dev = /dev/mantl/mantldata
+fstype = ext4
+mount = /mnt/mantldata

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -13,6 +13,7 @@ elasticsearch_executor_name: elasticsearch-executor-mantl
 elasticsearch_framework_version: 1.0.1-1
 elasticsearch_framework_name: mantl/elasticsearch
 elasticsearch_framework_ui_port: 31100
+elasticsearch_data_directory: "/mnt/mantldata/elasticsearch"
 
 # elasticsearch client node
 elasticsearch_client_id: mantl/elasticsearch-client

--- a/roles/elasticsearch/templates/elasticsearch.json.j2
+++ b/roles/elasticsearch/templates/elasticsearch.json.j2
@@ -11,6 +11,7 @@
         "java-heap": "{{ elasticsearch_java_opts }}"
       },
       "executor": {
+        "data-directory": "{{ elasticsearch_data_directory }}",
         "cluster-name": "{{ elasticsearch_cluster_name }}",
         "name": "{{ elasticsearch_executor_name }}",
         "cpu": {{ elasticsearch_executor_cpu }},

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -26,7 +26,7 @@ kafka_broker_options:
   - log.flush.scheduler.interval.ms=2000
   - log.retention.hours=72
   - log.flush.interval.messages=20000
-  - log.dirs=/mantl/a/dfs-data/kafka-logs\\,/mantl/b/dfs-data/kafka-logs\\,/mantl/c/dfs-data/kafka-logs\\,/mantl/d/dfs-data/kafka-logs\\,/mantl/e/dfs-data/kafka-logs\\,/mantl/f/dfs-data/kafka-logs
+  - log.dirs=/mnt/mantldata/kafka/a/dfs-data/kafka-logs\\,/mnt/mantldata/kafka/b/dfs-data/kafka-logs\\,/mnt/mantldata/kafka/c/dfs-data/kafka-logs\\,/mnt/mantldata/kafka/d/dfs-data/kafka-logs\\,/mnt/mantldata/kafka/e/dfs-data/kafka-logs\\,/mnt/mantldata/kafka/f/dfs-data/kafka-logs
   - log.index.interval.bytes=4096
   - socket.receive.buffer.bytes=10485
   - min.insync.replicas=2

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -8,7 +8,8 @@ mesos_agent_package: "mesos-agent-{{ mesos_version }}"
 mesos_mode: follower
 mesos_log_dir: /var/log/mesos
 mesos_logging_level: WARNING
-mesos_work_dir: /var/lib/mesos
+mesos_work_dir: /mnt/mesos
+mesos_lvm_data_volume_size: 20%FREE
 mesos_leader_port: 15050
 mesos_leader_proxy_port: 5050
 mesos_follower_port: 5051

--- a/roles/mesos/meta/main.yml
+++ b/roles/mesos/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
+  - role: lvm
   - role: handlers

--- a/roles/mesos/tasks/follower.yml
+++ b/roles/mesos/tasks/follower.yml
@@ -1,4 +1,31 @@
 ---
+- name: configure lvm for mesos data
+  sudo: yes
+  template:
+    src: 40-mesos-data-volume.conf.j2
+    dest: /etc/mantl/filesystems.d/40-mesos-data-volume.conf
+    mode: 0644
+  when: lvm_physical_device != ""
+  tags:
+    - mesos
+    - disk
+
+- name: process with mantl storage setup
+  sudo: yes
+  shell: "/usr/bin/mantl-storage-setup"
+  when: lvm_physical_device != ""
+  tags:
+    - mesos
+    - disk
+
+- name: create mesos work dir for non-lvm platforms
+  sudo: yes
+  shell: mkdir -p {{ mesos_work_dir }}
+  when: lvm_physical_device == ""
+  tags:
+    - mesos
+    - disk
+
 - name: install follower configuration
   sudo: yes
   yum:

--- a/roles/mesos/templates/40-mesos-data-volume.conf.j2
+++ b/roles/mesos/templates/40-mesos-data-volume.conf.j2
@@ -1,0 +1,10 @@
+[volume:mesos]
+group = mantl
+volume = mesos
+size = {{ mesos_lvm_data_volume_size }}
+
+[filesystem:mesos]
+dev = /dev/mantl/mesos
+fstype = ext4
+mount = /mnt/mesos
+required_by = mesos-agent.service

--- a/sample.yml
+++ b/sample.yml
@@ -94,3 +94,9 @@
     traefik_marathon_domain: marathon.localhost
   roles:
     - traefik
+
+# Configure the remaining portion of the attached disk on each node (if
+# applicable)
+- hosts: all
+  roles:
+    - disk

--- a/sample.yml
+++ b/sample.yml
@@ -49,6 +49,7 @@
   roles:
     - mesos
     - calico
+    - disk
 
 - hosts: role=kubeworker
   gather_facts: yes
@@ -56,6 +57,7 @@
     - calico
     - kubernetes
     - kubernetes-node
+    - disk
 
 # the control nodes are necessarily more complex than the worker nodes, and have
 # ZooKeeper, Mesos, and Marathon leaders. In addition, they control Vault to
@@ -94,9 +96,3 @@
     traefik_marathon_domain: marathon.localhost
   roles:
     - traefik
-
-# Configure the remaining portion of the attached disk on each node (if
-# applicable)
-- hosts: all
-  roles:
-    - disk


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

---
- configures mesos to use the external volume for its work directory (on lvm-backed platforms)
- adds new disk role to mount /mnt/mantldata using the remainder (by default) of the available space of the external disk  (on lvm-backed platforms)
- configures elasticsearch to use external disk for data storage (by default)
- configures kafka to use external disk for data storage (by default)

_When testing, make sure you update your local `mantl.yml` with the changes in `sample.yml`._

---

worker node:

``` shell
# pvdisplay
  --- Physical volume ---
  PV Name               /dev/sdb
  VG Name               mantl
  PV Size               100.00 GiB / not usable 4.00 MiB
  Allocatable           yes (but full)
  PE Size               4.00 MiB
  Total PE              25599
  Free PE               0
  Allocated PE          25599
  PV UUID               gxl8ca-x7cL-lAez-TBlF-eBpn-hfWV-KF0pfp

# lvdisplay
  --- Logical volume ---
  LV Path                /dev/mantl/docker
  LV Name                docker
  VG Name                mantl
  LV UUID                O6xkE1-Bu8d-uR5d-dvAl-DmVp-vjbb-AEOMUR
  LV Write Access        read/write
  LV Creation host, time resching-gce-worker-03, 2016-07-18 12:11:28 +0000
  LV Status              available
  # open                 1
  LV Size                40.00 GiB
  Current LE             10239
  Segments               1
  Allocation             inherit
  Read ahead sectors     auto
  - currently set to     8192
  Block device           253:0

  --- Logical volume ---
  LV Path                /dev/mantl/mesos
  LV Name                mesos
  VG Name                mantl
  LV UUID                2Cswhf-OFWf-VJ5I-XebR-SmMH-10Bz-LoRvwk
  LV Write Access        read/write
  LV Creation host, time resching-gce-worker-03, 2016-07-18 12:15:08 +0000
  LV Status              available
  # open                 1
  LV Size                12.00 GiB
  Current LE             3072
  Segments               1
  Allocation             inherit
  Read ahead sectors     auto
  - currently set to     8192
  Block device           253:1

  --- Logical volume ---
  LV Path                /dev/mantl/mantldata
  LV Name                mantldata
  VG Name                mantl
  LV UUID                ZpKxza-qWY6-OTJc-fQNS-RJRq-9fGh-VdhwEO
  LV Write Access        read/write
  LV Creation host, time resching-gce-worker-03, 2016-07-18 12:22:11 +0000
  LV Status              available
  # open                 1
  LV Size                48.00 GiB
  Current LE             12288
  Segments               1
  Allocation             inherit
  Read ahead sectors     auto
  - currently set to     8192
  Block device           253:2

# mount | grep -i mantl
/dev/mapper/mantl-docker on /var/lib/docker type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
/dev/mapper/mantl-mesos on /mnt/mesos type ext4 (rw,relatime,seclabel,data=ordered)
/dev/mapper/mantl-mantldata on /mnt/mantldata type ext4 (rw,relatime,seclabel,data=ordered)
```

kubeworker:

``` shell
# pvdisplay
  --- Physical volume ---
  PV Name               /dev/sdb
  VG Name               mantl
  PV Size               100.00 GiB / not usable 4.00 MiB
  Allocatable           yes (but full)
  PE Size               4.00 MiB
  Total PE              25599
  Free PE               0
  Allocated PE          25599
  PV UUID               Imnf7g-NLOa-BfXU-5Tci-v9dC-1Zz5-dklr8J

# lvdisplay
  --- Logical volume ---
  LV Path                /dev/mantl/docker
  LV Name                docker
  VG Name                mantl
  LV UUID                lUmlmw-vPe4-11JZ-NAc4-DsNr-ODcW-UsQhBu
  LV Write Access        read/write
  LV Creation host, time resching-gce-kubeworker-02, 2016-07-18 12:11:28 +0000
  LV Status              available
  # open                 1
  LV Size                40.00 GiB
  Current LE             10239
  Segments               1
  Allocation             inherit
  Read ahead sectors     auto
  - currently set to     8192
  Block device           253:0

  --- Logical volume ---
  LV Path                /dev/mantl/mantldata
  LV Name                mantldata
  VG Name                mantl
  LV UUID                EpIxel-LWN2-HTz9-S147-mQAK-f7wU-f2UhFW
  LV Write Access        read/write
  LV Creation host, time resching-gce-kubeworker-02, 2016-07-18 12:22:10 +0000
  LV Status              available
  # open                 1
  LV Size                60.00 GiB
  Current LE             15360
  Segments               1
  Allocation             inherit
  Read ahead sectors     auto
  - currently set to     8192
  Block device           253:1

# mount | grep -i mantl
/dev/mapper/mantl-docker on /var/lib/docker type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
/dev/mapper/mantl-mantldata on /mnt/mantldata type ext4 (rw,relatime,seclabel,data=ordered)
```
