### PR TITLE
Add shell.nix with definition of all requirements

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ nixpkgs ? import <nixpkgs> { } }:
+
+with nixpkgs;
+
+let  mkEnv = { stdenv, python27, pythonPackages, openssl }:
+  stdenv.mkDerivation {
+    name = "mantl-env";
+    buildInputs = [ python27 pythonPackages.pyyaml openssl terraform packer ansible2 openssh ];
+  };
+in callPackage mkEnv {}


### PR DESCRIPTION
Add shell.nix with definition of all requirements including ssh, terraform, packer, ansible, and tools needed for ./security-setup
