### PR TITLE
[TRAVIS] Expand skipping logic in travis.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ env:
   - TERRAFORM_VERSION=0.7.0-rc2
   matrix:
   # These providers have a full battery of Terraform+Ansible tests
-  - PROVIDER=aws DOCKER_SECRETS='-e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID'
-  - PROVIDER=do  DOCKER_SECRETS='-e DIGITALOCEAN_TOKEN'
-  - PROVIDER=gce DOCKER_SECRETS='-e GOOGLE_CREDENTIALS'
+  - PROVIDER=aws
+  - PROVIDER=do
+  - PROVIDER=gce
   # These providers are only linted using `terraform plan`, and have no secrets
   # Secrets are available for CLC, but the build times out.
-  - PROVIDER=clc DOCKER_SECRETS='-e CLC_USERNAME -e CLC_PASSWORD'
+  - PROVIDER=clc
   - PROVIDER=softlayer
   - PROVIDER=triton
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ install:
 
 before_script:
   - export TERRAFORM_FILE=testing/terraform/${PROVIDER}.tf
-  - export CI_HEAD_COMMIT=$(git rev-list -n 1 --no-merges --branches="$(git rev-parse --abbrev-ref HEAD)" master...HEAD)
-  - echo $CI_HEAD_COMMIT
 
 script:
   - python testing/travis.py script

--- a/testing/travis.py
+++ b/testing/travis.py
@@ -125,7 +125,7 @@ def run_cmds(cmds, fail_sequential=False):
 
 
 def skip(diff_names):
-    if os.environ['TRAVIS_BRANCH'] is not 'master' and os.environ["TRAVIS_PULL_REQUEST"]:
+    if os.environ['TRAVIS_BRANCH'] != 'master' and os.environ["TRAVIS_PULL_REQUEST"]:
         logging.info("We don't want to build on pushes to branches that aren't master.")
         return True
 

--- a/testing/travis.py
+++ b/testing/travis.py
@@ -137,8 +137,8 @@ def skip(diff_names):
         (lambda f: f == '.mention-bot', "All changes were for bot config files"),
     ]
 
-    for fltr, log in filter_and_explaination:
-        if len([f for f in diff_names.split() if fltr(f)]) < 1:
+    for pred, log in filter_and_explaination:
+        if len([f for f in diff_names.split() if not pred(f)]) < 1:
             logging.info(log)
             return True
 

--- a/testing/travis.py
+++ b/testing/travis.py
@@ -125,11 +125,11 @@ def run_cmds(cmds, fail_sequential=False):
 
 
 def skip(diff_names):
-    if os.environ['TRAVIS_SECURE_ENV_VARS'] == 'false':
+    if os.environ.get('TRAVIS_SECURE_ENV_VARS', 'false') == 'false':
         logging.info("Deploy secrets are not available for forks")
         return True
 
-    filter_and_explaination = [
+    filter_and_explanation = [
         (lambda f: f.startswith('docs') or any([f.endswith(ext) for ext in ['md', 'rst']]),
                 "All changes were for documentation files"),
         (lambda f: f.startswith('addons'), "All changes were for addons"),
@@ -137,8 +137,8 @@ def skip(diff_names):
         (lambda f: f == '.mention-bot', "All changes were for bot config files"),
     ]
 
-    for pred, log in filter_and_explaination:
-        if len([f for f in diff_names.split() if not pred(f)]) < 1:
+    for pred, log in filter_and_explanation:
+        if not pred(diff_names.split()):
             logging.info(log)
             return True
 
@@ -226,10 +226,6 @@ def health_checks():
                 timeout += 5
 
             except ValueError as e:
-                logging.warn("Error decoding JSON: {}".format(e))
-
-            except IOError as e:
-                logging.warn("Unknown error: {}".format(e))
                 logging.warn("Error decoding JSON: {}".format(e))
 
             except IOError as e:

--- a/testing/travis.py
+++ b/testing/travis.py
@@ -137,10 +137,6 @@ def skip(diff_names):
     return False
 
 
-def deploy_to_cloud_cmds():
-    return cmds
-
-
 def get_credentials():
     """ Get consul api password from security.yml """
     # TODO: Should we just add pyyaml as a dependency?

--- a/testing/travis.py
+++ b/testing/travis.py
@@ -138,7 +138,7 @@ def skip(diff_names):
     ]
 
     for fltr, log in filter_and_explaination:
-        if len([f for f in diff_names.split if fltr(f)]) < 1:
+        if len([f for f in diff_names.split() if fltr(f)]) < 1:
             logging.info(log)
             return True
 

--- a/testing/travis.py
+++ b/testing/travis.py
@@ -125,6 +125,7 @@ def run_cmds(cmds, fail_sequential=False):
 
 
 def skip(diff_names):
+    logging.info(os.environ['TRAVIS_SECURE_ENV_VARS'])
     if not os.environ['TRAVIS_SECURE_ENV_VARS']:
         logging.info("Deploy secrets are not available for forks")
         return True

--- a/testing/travis.py
+++ b/testing/travis.py
@@ -125,8 +125,8 @@ def run_cmds(cmds, fail_sequential=False):
 
 
 def skip(diff_names):
-    if os.environ['TRAVIS_BRANCH'] != 'master' and os.environ["TRAVIS_PULL_REQUEST"]:
-        logging.info("We don't want to build on pushes to branches that aren't master.")
+    if os.environ['TRAVIS_SECURE_ENV_VARS']:
+        logging.info("Deploy secrets are not available for forks")
         return True
 
     is_doc = lambda f: f.startswith('docs') or any([f.endswith(ext) for ext in ['md', 'rst']])

--- a/testing/travis.py
+++ b/testing/travis.py
@@ -125,8 +125,7 @@ def run_cmds(cmds, fail_sequential=False):
 
 
 def skip(diff_names):
-    logging.info(os.environ['TRAVIS_SECURE_ENV_VARS'])
-    if not os.environ['TRAVIS_SECURE_ENV_VARS']:
+    if os.environ['TRAVIS_SECURE_ENV_VARS'] == 'false':
         logging.info("Deploy secrets are not available for forks")
         return True
 


### PR DESCRIPTION
The logic for skipping builds for PRs vanished, so I added it back in,
expanding the `filter_doc_files` into a skip function. It takes the list
of changes, and returns a bool. Other skipping logic could go in here
- [x] doesn't skip builds for non-fork PRs
- [x] does skip builds for fork PRs
