### PR TITLE
Add collectd-monasca role that deploys custom collectd code

### DIFF
--- a/addons/collectd-monasca.yml
+++ b/addons/collectd-monasca.yml
@@ -1,0 +1,12 @@
+# Install collectd with monasca style metrics to Kafka. Run this playbook after
+# running the core playbook # (sample.yml)
+
+
+# CHECK SECURITY - when customizing you should leave this in. If you take it out
+# and forget to specify security.yml, security could be turned off on components
+# in your cluster!
+- include: "{{ playbook_dir }}/../playbooks/check-requirements.yml"
+
+- hosts: all
+  roles:
+    - collectd-monasca

--- a/roles/collectd-monasca/README.rst
+++ b/roles/collectd-monasca/README.rst
@@ -1,0 +1,86 @@
+Collectd
+========
+
+Collectd role for deploying Collectd.
+
+Installation
+------------
+
+As of 1.1.0, Collectd is distributed as an addon for Mantl. After a successful
+initial run from your customized ``sample.yml``, install it with
+``ansible-playbook -e @security.yml addons/collectd.yml``.
+
+Variables
+---------
+
+This role has the following global settings:
+
+.. data ::  Hostname  
+
+   Hostname to append to metrics                    
+   
+   Default: ``{{ inventory_hostname }}``
+
+.. data ::  Interval  
+
+   Global interval for sampling and sending metrics
+
+   Default: ``10 seconds``
+
+This role enables the following Collectd plugins and settings:
+
+.. data ::  cpu        
+
+   Type: read
+   Description: amount of time spent by the CPU in various states
+
+.. data ::  disk
+
+   Type: read 
+   Description: performance statistics for block devices and partitions
+
+.. data ::  df 
+
+   Type: read  
+   Description : file system usage information
+   Default: exclude all system and obsure file system types
+
+.. data ::  interface  
+
+   Type: read  
+   Description: network interface throughput, packets/s, errors                                                            
+.. data ::  load
+
+   Type: read  
+   Description: system load                                                                                                
+.. data ::  memory     
+
+   Type: read  
+   Description: physical memory utilization                                                                                
+.. data ::  processes  
+
+   Type: read  
+   Description: number of processes grouped by state                                                                       
+.. data ::  swap       
+
+   Type: read  
+   Description: amount of memory currently written to swap disk                                                            
+.. data ::  uptime     
+
+   Type: read  
+   Description: system uptime                                                                                              
+.. data ::  users      
+
+   Type: read  
+   Description: counts the number of users currently logged into the system                                                
+.. data ::  network    
+
+   Type: write 
+   Description: send metrics to collectd compatible receiver                
+   Default: ``Server "localhost" "25826"``
+
+.. data ::  syslog     
+
+   Type: write 
+   Description: write collectd logs to syslog                               
+   Default: ``LogLevel "err"``

--- a/roles/collectd-monasca/README.rst
+++ b/roles/collectd-monasca/README.rst
@@ -1,27 +1,29 @@
 Collectd
 ========
 
-Collectd role for deploying Collectd.
+CollectD-Monasca role for deploying custom build CollectD with:
+  1. customized plugin-write_kafka that outputs a single metric per message
+  2. custom formatter "Monasca" that builds a JSON appropriate for monasca-persister
 
 Installation
 ------------
 
-As of 1.1.0, Collectd is distributed as an addon for Mantl. After a successful
+CollectD-Monasca is distributed as an addon for Mantl. After a successful
 initial run from your customized ``sample.yml``, install it with
-``ansible-playbook -e @security.yml addons/collectd.yml``.
+``ansible-playbook -e @security.yml addons/collectd-monasca.yml``.
 
 Variables
 ---------
 
 This role has the following global settings:
 
-.. data ::  Hostname  
+.. data ::  Hostname
 
-   Hostname to append to metrics                    
-   
+   Hostname to append to metrics
+
    Default: ``{{ inventory_hostname }}``
 
-.. data ::  Interval  
+.. data ::  Interval
 
    Global interval for sampling and sending metrics
 
@@ -29,58 +31,47 @@ This role has the following global settings:
 
 This role enables the following Collectd plugins and settings:
 
-.. data ::  cpu        
+.. data ::  cpu
 
    Type: read
    Description: amount of time spent by the CPU in various states
 
 .. data ::  disk
 
-   Type: read 
+   Type: read
    Description: performance statistics for block devices and partitions
 
-.. data ::  df 
+.. data ::  df
 
-   Type: read  
+   Type: read
    Description : file system usage information
    Default: exclude all system and obsure file system types
 
-.. data ::  interface  
+.. data ::  interface
 
-   Type: read  
-   Description: network interface throughput, packets/s, errors                                                            
+   Type: read
+   Description: network interface throughput, packets/s, errors
 .. data ::  load
 
-   Type: read  
-   Description: system load                                                                                                
-.. data ::  memory     
+   Type: read
+   Description: system load
+.. data ::  memory
 
-   Type: read  
-   Description: physical memory utilization                                                                                
-.. data ::  processes  
+   Type: read
+   Description: physical memory utilization
+.. data ::  network
 
-   Type: read  
-   Description: number of processes grouped by state                                                                       
-.. data ::  swap       
-
-   Type: read  
-   Description: amount of memory currently written to swap disk                                                            
-.. data ::  uptime     
-
-   Type: read  
-   Description: system uptime                                                                                              
-.. data ::  users      
-
-   Type: read  
-   Description: counts the number of users currently logged into the system                                                
-.. data ::  network    
-
-   Type: write 
-   Description: send metrics to collectd compatible receiver                
+   Type: write
+   Description: send metrics to collectd compatible receiver
    Default: ``Server "localhost" "25826"``
+.. data ::  syslog
 
-.. data ::  syslog     
-
-   Type: write 
-   Description: write collectd logs to syslog                               
+   Type: write
+   Description: write collectd logs to syslog
    Default: ``LogLevel "err"``
+.. data ::  write_kafka
+
+   Type: write
+   Description: send metrics to Kafka topic
+   Default: ``Brokers "broker-1.service.consul:9092,broker-2.service.consul:9092,broker-3.service.consul:9092"``
+   Default: ``Topic "metrics"``

--- a/roles/collectd-monasca/defaults/main.yml
+++ b/roles/collectd-monasca/defaults/main.yml
@@ -1,3 +1,15 @@
 ---
-collectd_image: tpolekhin/collectd-monasca
+# CollectD docker container
+collectd_image: ciscocloud/collectd
 collectd_image_tag: 5.5.2
+
+# Configure CollectD network output
+collectd_output_network: true
+collectd_output_network_server_addr: localhost
+collectd_output_network_server_port: 25826
+
+# Configure CollectD kafka output
+collectd_output_kafka: false
+collectd_output_kafka_broker_list: broker-1.service.consul:9092,broker-2.service.consul:9092,broker-3.service.consul:9092
+collectd_output_kafka_topic: metrics
+collectd_output_kafka_format: Monasca

--- a/roles/collectd-monasca/defaults/main.yml
+++ b/roles/collectd-monasca/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+collectd_image: tpolekhin/collectd-monasca
+collectd_image_tag: 5.5.2

--- a/roles/collectd-monasca/handlers/main.yml
+++ b/roles/collectd-monasca/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart collectd
+  sudo: yes
+  service:
+    name: collectd
+    state: restarted
+  tags:
+    - collectd
+
+- name: systemd daemon-reload
+  sudo: yes
+  command: systemctl daemon-reload

--- a/roles/collectd-monasca/tasks/main.yml
+++ b/roles/collectd-monasca/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: create collectd configration dir
+  sudo: yes
+  file:
+    path: /etc/collectd.d
+    state: directory
+  tags:
+    - collectd-monasca
+
+- name: configure collectd
+  sudo: yes
+  template:
+    src: collectd.conf.j2
+    dest: /etc/collectd.conf
+  notify:
+    - restart collectd
+  tags:
+    - collectd-monasca
+
+- name: install collectd systemd service
+  sudo: yes
+  template:
+    src: collectd.service.j2
+    dest: /usr/lib/systemd/system/collectd.service
+  notify:
+    - systemd daemon-reload
+  tags:
+    - collectd-monasca
+
+- name: enable and start collectd
+  sudo: yes
+  service:
+    enabled: yes
+    name: collectd
+    state: started
+  tags:
+    - collectd-monasca

--- a/roles/collectd-monasca/templates/collectd.conf.j2
+++ b/roles/collectd-monasca/templates/collectd.conf.j2
@@ -1,0 +1,77 @@
+# collectd
+
+Hostname "{{ inventory_hostname }}"
+Interval 10
+Include "/etc/collectd.d/"
+TypesDB "/usr/share/collectd/types.db"
+
+LoadPlugin "cpu"
+LoadPlugin "disk"
+LoadPlugin "df"
+LoadPlugin "interface"
+LoadPlugin "load"
+LoadPlugin "memory"
+LoadPlugin "syslog"
+
+<Plugin "cpu">
+  ReportByState true
+  ReportByCpu false
+  ValuesPercentage true
+</Plugin>
+
+<Plugin "memory">
+  ValuesPercentage true
+  ValuesAbsolute true
+</Plugin>
+
+<Plugin "df">
+  FSType anon_inodefs
+  FSType bdev
+  FSType cgroup
+  FSType cpuset
+  FSType debugfs
+  FSType devpts
+  FSType devtmpfs
+  FSType ecryptfs
+  FSType fuse
+  FSType fusectl
+  FSType hugetlbfs
+  FSType mqueue
+  FSType nfs
+  FSType nfs4
+  FSType nfsd
+  FSType pipefs
+  FSType proc
+  FSType pstore
+  FSType ramfs
+  FSType rootfs
+  FSType rpc_pipefs
+  FSType securityfs
+  FSType sockfs
+  FSType sysfs
+  FSType tmpfs
+  FSType vboxsf
+  IgnoreSelected true
+  ReportByDevice false
+  ValuesAbsolute true
+  ValuesPercentage true
+  ReportInodes true
+</Plugin>
+
+<Plugin "interface">
+  Interface "/^veth/"
+  IgnoreSelected true
+</Plugin>
+
+<Plugin "syslog">
+  LogLevel "err"
+</Plugin>
+
+<Plugin "write_kafka">
+  Property "metadata.broker.list" "broker-1.service.consul:9092,broker-2.service.consul:9092,broker-3.service.consul:9092"
+  <Topic "metrics">
+    Format Monasca
+  </Topic>
+</Plugin>
+
+# EOF

--- a/roles/collectd-monasca/templates/collectd.conf.j2
+++ b/roles/collectd-monasca/templates/collectd.conf.j2
@@ -67,11 +67,21 @@ LoadPlugin "syslog"
   LogLevel "err"
 </Plugin>
 
+{% if collectd_output_network %}
+LoadPlugin "network"
+<Plugin "network">
+  Server "{{ collectd_output_network_server_addr }}" "{{ collectd_output_network_server_port }}"
+</Plugin>
+{% endif %}
+
+{% if collectd_output_kafka %}
+LoadPlugin "write_kafka"
 <Plugin "write_kafka">
-  Property "metadata.broker.list" "broker-1.service.consul:9092,broker-2.service.consul:9092,broker-3.service.consul:9092"
-  <Topic "metrics">
-    Format Monasca
+  Property "metadata.broker.list" "{{ collectd_output_kafka_broker_list }}"
+  <Topic "{{ collectd_output_kafka_topic }}">
+    Format {{ collectd_output_kafka_format }}
   </Topic>
 </Plugin>
+{% endif %}
 
 # EOF

--- a/roles/collectd-monasca/templates/collectd.service.j2
+++ b/roles/collectd-monasca/templates/collectd.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=collectd
+After=docker.service
+Requires=docker.service
+Requires=dnsmasq.service
+
+[Service]
+Restart=always
+RestartSec=20
+TimeoutStartSec=20m
+
+ExecStartPre=-/usr/bin/docker pull {{ collectd_image }}:{{ collectd_image_tag }}
+ExecStartPre=-/usr/bin/docker rm -f collectd
+
+ExecStart=/usr/bin/docker run \
+    --rm \
+    --name=collectd \
+    --hostname={{ inventory_hostname }} \
+    --log-driver=none \
+    --privileged=true \
+    --volume=/proc:/mnt/proc \
+    --env="COLLECTD_HOSTNAME={{ inventory_hostname }}" \
+    {{ collectd_image }}:{{ collectd_image_tag }}
+
+ExecStop=/usr/bin/docker rm -f collectd
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add collectd-monasca role that deploys custom collectd code to send monasca style metrics to Kafka.
