### PR TITLE
Add last missing slash: Fixes issue #1779 

### DIFF
--- a/roles/calico/files/neutron_port_update.py
+++ b/roles/calico/files/neutron_port_update.py
@@ -125,6 +125,8 @@ if __name__ == "__main__":
     catalog = get_catalog()
     token = get_token(catalog)
     public_url = neutron_public_url(catalog)
+    if not public_url.endswith('/'):
+        public_url = public_url + "/"
     ports = list_ports(token, public_url)
 
     exit_code = 0 # no update to port


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes

In some OpenStack labs, the publicURL for neutron may not be configured
as expected. Add missing slash if needed.
