### PR TITLE
[TRAVIS] Use remote tfstate to simplify CI ops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - python testing/travis.py install
 
 before_script:
+  - terraform remote config -backend=s3 -backend-config='bucket=mantl-ci-remote-tfstate' -backend-config='key=${PROVIDER}/terraform.tfstate' -backend-config='region=us-west-1'
   - export TERRAFORM_FILE=testing/terraform/${PROVIDER}.tf
   - export CI_HEAD_COMMIT=$(git rev-list -n 1 --no-merges --branches="$(git rev-parse --abbrev-ref HEAD)" master...HEAD)
   - echo $CI_HEAD_COMMIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - python testing/travis.py install
 
 before_script:
-  - terraform remote config -backend=s3 -backend-config='bucket=mantl-ci-remote-tfstate' -backend-config='key=${PROVIDER}/terraform.tfstate' -backend-config='region=us-west-1'
+  - terraform remote config -backend=s3 -backend-config='bucket=mantl-ci-remote-tfstate' -backend-config="key=${PROVIDER}/terraform.tfstate" -backend-config='region=us-west-1'
   - export TERRAFORM_FILE=testing/terraform/${PROVIDER}.tf
   - export CI_HEAD_COMMIT=$(git rev-list -n 1 --no-merges --branches="$(git rev-parse --abbrev-ref HEAD)" master...HEAD)
   - echo $CI_HEAD_COMMIT


### PR DESCRIPTION
- N/A Installs cleanly on a fresh build of most recent master branch
- N/A Upgrades cleanly from the most recent release
- N/A Updates documentation relevant to the changes

Our CI builds do not currently preserve state between builds. When
the destroy step doesn't trigger properly, infrastructure can hang
around, and that causes cascading quota failures in subsequent builds.
We could cache the tfstate within Travis, but that doesn't allow any
other tools access to the tfstate, which would be useful for external
tools. Therefore, we can use remote tfstate to allow for state to
persist, as well as expose the information to other tools we may create.

Supercedes and closes #1718
