### PR TITLE
Updated outdated glusterfs repo, use EPEL repo instead

### DIFF
--- a/roles/glusterfs/defaults/main.yml
+++ b/roles/glusterfs/defaults/main.yml
@@ -3,9 +3,7 @@
 glusterfs_mode: client
 
 # software sources
-glusterfs_version: 3.7.6
-glusterfs_repo: https://download.gluster.org/pub/gluster/glusterfs/{{glusterfs_version.split(".")[:2]|join(".")}}/{{glusterfs_version}}/EPEL.repo/glusterfs-epel.repo
-glusterfs_repo_sha256sum: ee06398d5b09d230fa3ffad4995b83089012a426265741c58a70bf587d14613c.
+glusterfs_repo_package: centos-release-gluster37
 
 # clustering and replication
 glusterfs_replication: "{{ groups[glusterfs_server_group] | count }}"

--- a/roles/glusterfs/tasks/main.yml
+++ b/roles/glusterfs/tasks/main.yml
@@ -1,10 +1,9 @@
 ---
-- name: enable community repo
+- name: install glusterfs repo package
   sudo: yes
-  get_url:
-    url: "{{ glusterfs_repo }}"
-    dest: /etc/yum.repos.d/glusterfs-epel.repo
-    sha256sum: "{{ glusterfs_repo_sha256sum }}"
+  yum:
+    name: "{{ glusterfs_repo_package }}"
+    state: present
   tags:
     - glusterfs
 


### PR DESCRIPTION
The glusterfs repo has changed and is now in the CentOS Extras repository and Ansible provisioning fails because of this, please merge this to fix problem.

More info about changed repo at:
https://download.gluster.org/pub/gluster/glusterfs/3.7/LATEST/CentOS/
