### PR TITLE
Use epel-release package 

### DIFF
--- a/packer/scripts/ansible.sh
+++ b/packer/scripts/ansible.sh
@@ -3,7 +3,7 @@
 update-ca-trust
 
 # Install EPEL repository
-rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
+yum -y install epel-release
 
 # Install Ansible
 yum -y install ansible


### PR DESCRIPTION
The epel repository used to download ansible when building the packer box does not exist:

```
curl -I http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
HTTP/1.1 404 Not Found
Date: Thu, 22 Sep 2016 17:20:28 GMT
Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips
Content-Type: text/html; charset=iso-8859-1

```
