### PR TITLE
possible circular dependency in mantl-storage-setup.service

### DIFF
--- a/roles/lvm/files/mantl-storage-setup.service
+++ b/roles/lvm/files/mantl-storage-setup.service
@@ -1,5 +1,6 @@
 [Unit]
 Before=local-fs.target docker.service docker-storage-setup.service
+DefaultDependencies=no
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Updates mantl-storage-setup unit to avoid possible circular dependency with local-fs.target. Tested on bare-metal.

> Unless DefaultDependencies= in the "[Unit]" is set to false, service units will implicitly have dependencies of type Requires= and After= on sysinit.target, a dependency of type After= on basic.target as well as dependencies of type Conflicts= and Before= on shutdown.target. These ensure that normal service units pull in basic system initialization, and are terminated cleanly prior to system shutdown. Only services involved with early boot or late system shutdown should disable this option.

References

[1] [systemd.service — Service unit configuration](https://www.freedesktop.org/software/systemd/man/systemd.service.html#)
[2] [structural overview of well-known units and their position in the boot-up logic](https://www.freedesktop.org/software/systemd/man/bootup.html)
