### PR TITLE
bump nginx-mantlui container to 0.7.2

### DIFF
--- a/roles/mantlui/defaults/main.yml
+++ b/roles/mantlui/defaults/main.yml
@@ -1,4 +1,4 @@
 mantlui_nginx_image: ciscocloud/nginx-mantlui
-mantlui_nginx_image_tag: 0.7.1
+mantlui_nginx_image_tag: 0.7.2
 do_mantlui_ssl: false
 do_mantlui_auth: false


### PR DESCRIPTION
currently roles/mantlui/defaults/main.yml specifies nginx-mantlui version 0.7.1

This will cause mesos ui to fail as an empty upstream in the nginx.conf file is created for
kubernetes_api (copy and paste error, it is looking for service mesos).

This bug will only be seen if consul reports no kubernetes.

Symptoms:

mesos ui continually says "unable to connect to <mantl controller:443>"
mesos itself is running fine and marathon has no problem.

/var/log/nginx/error.log
2016/12/01 18:53:59 [emerg] 399#0: no servers are inside upstream in /etc/nginx/nginx.conf:36

This is fixed by the Aug 22 commit to nginx-mantlui
https://github.com/CiscoCloud/nginx-mantlui/blob/master/nginx.tmpl

which is included in the 0.7.2 nginx-mantlui container