### PR TITLE
Fix broken second table of contents

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -51,6 +51,7 @@ Here are some guides specific to each of the platforms that Mantl supports:
    triton.rst
 
 Community-supported platform:
+
 .. toctree::
    :maxdepth:1
         


### PR DESCRIPTION
You were missing a new line in the "Getting started" index page, added it to fix the broken table of contents.