### PR TITLE
Update consul.cfg.j2

### DIFF
--- a/roles/consul-template/templates/consul.cfg.j2
+++ b/roles/consul-template/templates/consul.cfg.j2
@@ -1,4 +1,4 @@
-consul = "127.0.0.1:8500"
+consul = "0.0.0.0:8500"
 log_level = "warn"
 token = "{{ consul_acl_master_token }}"
 


### PR DESCRIPTION
Local service is trying to use consul.service.consul versus 127.0.0.1, so changed to 0.0.0.0 so it gets picked up on the default external IP.  Given this file hasn't changed, I am not certain the entire repercussions of this.  As it stands though, deploying to AWS doesn't work without the change (again, there might be a better fix.)  Specifically, the UI is down, suspect due to lack of Consul access.

Hi, thank you for your contribution to Mantl! Before we can accept any code into
master, we need it to meet the following criteria. If there are any you can't
satisfy yourself, go ahead and open the pull request anyway and we'll help you
test. Feel free to delete this message once you're done. Thanks again!

- [ ] Installs cleanly on a fresh build of most recent master branch
It also fixed master
- [ ] Upgrades cleanly from the most recent release
Didn't try update from 1.2 to master (did two separate installs)
- [ ] Updates documentation relevant to the changes
Not sure where this would be documented.  I hunted it down by trying to access the UI which didn't work, noticed docker-proxy on port 80 on the control nodes, but no nginx process running.  Checked the container that was running and its logs said it couldn't connect to consul.service.consul.  Checked the DNS, it was for the external IP not 127.0.0.1 which is what the template has.  

I had a related bug issued here #1864
