### PR TITLE
Use list for vault_command_options variable

### DIFF
--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
 vault_package: vault-0.6.0
 vault_default_port: 8200
-vault_command_options: >
-  --ca-cert=/etc/pki/CA/ca.cert
-  --client-cert={{ host_cert }}
-  --client-key={{ host_key }}
+vault_command_options:
+  - "--ca-cert=/etc/pki/CA/ca.cert"
+  - "--client-cert={{ host_cert }}"
+  - "--client-key={{ host_key }}"
 
 vault_init_json: '{
 	"secret_shares": 5,

--- a/roles/vault/templates/vault.unseal.j2
+++ b/roles/vault/templates/vault.unseal.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{% for key in vault_keys %}vault unseal {{ vault_command_options }} {{ key }}
+{% for key in vault_keys %}vault unseal {{ vault_command_options|join(' ') }} {{ key }}
 {% endfor %}
 
 exit 0


### PR DESCRIPTION
This in order to avoid unexpected end-of-line in a file /usr/local/bin/vault-unseal.sh
This causes error because a {{ key }} variable is perceived as a command