### PR TITLE
Point to correct version of RPM

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -11,8 +11,8 @@ fi
 # enable EPEL and get sshpass if it's not already installed
 if ! sshpass; then
   if ! yum list installed epel-release > /dev/null; then
-    curl -f -S -s -O 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm'
-    rpm -ivh epel-release-7-6.noarch.rpm
+    curl -f -S -s -O 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm'
+    rpm -ivh epel-release-7-9.noarch.rpm
   fi
   yum install -y --enablerepo=epel sshpass
 fi


### PR DESCRIPTION
7.6 no longer exists. It is 7.9

Hi, thank you for your contribution to Mantl! Before we can accept any code into
master, we need it to meet the following criteria. If there are any you can't
satisfy yourself, go ahead and open the pull request anyway and we'll help you
test. Feel free to delete this message once you're done. Thanks again!

- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
