### PR TITLE
[JOURNALD] Enable persistent storage for journal

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -42,6 +42,24 @@
   tags:
     - common
 
+- name: change journald storage to persistent
+  become: yes
+  lineinfile:
+    dest: /etc/systemd/journald.conf
+    regexp: "^Storage=auto"
+    line: Storage=persistent
+  tags:
+    - common
+
+- name: restart journald service
+  become: yes
+  service:
+    name: systemd-journald
+    state: reloaded
+  tags:
+    - common
+
+
 # add yum-utils if not already installed
 - name: add yum-config-manager
   sudo: yes


### PR DESCRIPTION
On CentOS 7, journald is set to persist logs across boots only if a
file is created by a system administrator. With this commit, we add a
line to the journald config file to persist the log data.

Hi, thank you for your contribution to Mantl! Before we can accept any code into
master, we need it to meet the following criteria. If there are any you can't
satisfy yourself, go ahead and open the pull request anyway and we'll help you
test. Feel free to delete this message once you're done. Thanks again!

- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
