### PR TITLE
Added all k8 addon pods to the host network. There seems to be an issue wit…

### DIFF
--- a/roles/kubernetes-master/templates/kubernetes-dashboard.yml
+++ b/roles/kubernetes-master/templates/kubernetes-dashboard.yml
@@ -32,6 +32,7 @@ items:
         labels:
           app: kubernetes-dashboard
       spec:
+        hostNetwork: true
         containers:
         - name: kubernetes-dashboard
           image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.1.0

--- a/roles/kubernetes-master/templates/skydns-rc.yaml.j2
+++ b/roles/kubernetes-master/templates/skydns-rc.yaml.j2
@@ -19,6 +19,7 @@ spec:
         version: v8
         kubernetes.io/cluster-service: "true"
     spec:
+      hostNetwork: true
       containers:
       - name: kube2sky
         image: gcr.io/google_containers/kube2sky:1.11


### PR DESCRIPTION
…h calico forwarding k8 container traffic to the rest of the cluster

This is a temporary workaround for the dashboard and dns pods that are deployed on the calico network to rather go the the k8 host network since there seems to be an issue with the calico network routing to the outside world

In my opinion all kube-system stuff can be on the hot network and then we can have calico network for all custom deployed things

- [y] Installs cleanly on a fresh build of most recent master branch
- [y] Upgrades cleanly from the most recent release
- [?] Updates documentation relevant to the changes
