### PR TITLE
Should fix the occasional defaut token missing if the dns stwarts up …

### DIFF
--- a/roles/kubernetes-master/tasks/main.yml
+++ b/roles/kubernetes-master/tasks/main.yml
@@ -89,6 +89,8 @@
   tags:
     - kubernetes
 
+- pause: seconds=30
+
 - include: skydns.yml
   when: dns_setup
   tags:

--- a/roles/kubernetes-master/tasks/main.yml
+++ b/roles/kubernetes-master/tasks/main.yml
@@ -89,7 +89,8 @@
   tags:
     - kubernetes
 
-- pause: seconds=30
+- name: wait for k8 to settle down
+  pause: seconds=30
 
 - include: skydns.yml
   when: dns_setup


### PR DESCRIPTION
…too soon

This race condition still happens occasionally and have not seen it with this pause. Seem to be more prominent if you if you deploy more k8 workers that need to sync:
[centos@mantl-control-01 addons]$ kubectl logs kube-dns-v8-8t9q6 kube2sky
I0423 15:24:09.019199       1 kube2sky.go:389] Etcd server found: http://10.1.3.156:2379
I0423 15:24:10.021263       1 kube2sky.go:455] Using https://10.254.0.1:443 for kubernetes master
I0423 15:24:10.021284       1 kube2sky.go:456] Using kubernetes API 
E0423 15:24:10.037880       1 reflector.go:136] Failed to list *api.Service: the server has asked for the client to provide credentials (get services)
E0423 15:24:10.038683       1 reflector.go:136] Failed to list *api.Endpoints: the server has asked for the client to provide credentials (get endpoints)


- [y] Installs cleanly on a fresh build of most recent master branch
- [y] Upgrades cleanly from the most recent release
- [?] Updates documentation relevant to the changes
