### PR TITLE
Added aws ec2.internal namespace keys

### DIFF
--- a/roles/certificates/defaults/main.yml
+++ b/roles/certificates/defaults/main.yml
@@ -1,3 +1,4 @@
+
 ---
 generate_certificate_package: generate-certificate-0.1.1-1
 
@@ -14,8 +15,10 @@ location: "{{ inventory_hostname }}" # Openssl's "CN" ("Common Name"). Can't be 
 dns:
   - "{{ inventory_hostname }}"
   - "{{ inventory_hostname }}.node.consul"
+  - "{{ inventory_hostname }}.ec2.internal"
   - "{{ ansible_hostname }}"
   - "{{ ansible_hostname }}.node.consul"
+  - "{{ ansible_hostname }}.ec2.intenal"
   - "*.service.consul"
   - "kubernetes.default.svc.{{ cluster_name }}"
 # What IP addresses will this certificate be valid for?


### PR DESCRIPTION
On AWS there namepaces are in the assets names then no log key access on k8 works
This adds the aws *.ec2.internal namespace to the set of keys

- [y] Installs cleanly on a fresh build of most recent master branch
- [y] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
