### PR TITLE
Fixed typo in dns host name for aws instances

### DIFF
--- a/roles/certificates/defaults/main.yml
+++ b/roles/certificates/defaults/main.yml
@@ -18,7 +18,7 @@ dns:
   - "{{ inventory_hostname }}.ec2.internal"
   - "{{ ansible_hostname }}"
   - "{{ ansible_hostname }}.node.consul"
-  - "{{ ansible_hostname }}.ec2.intenal"
+  - "{{ ansible_hostname }}.ec2.internal"
   - "*.service.consul"
   - "kubernetes.default.svc.{{ cluster_name }}"
 # What IP addresses will this certificate be valid for?

--- a/terraform/aws/iam/main.tf
+++ b/terraform/aws/iam/main.tf
@@ -2,7 +2,7 @@ variable "short_name" {default = "mantl"}
 
 resource "aws_iam_instance_profile" "control_profile" {
   name = "${var.short_name}-control-profile"
-  roles = ["${aws_iam_role.control_role.name}"]
+  role = "${aws_iam_role.control_role.name}"
 }
 
 resource "aws_iam_role_policy" "control_policy" {
@@ -54,7 +54,7 @@ output "control_iam_instance_profile" {
 
 resource "aws_iam_instance_profile" "worker_profile" {
   name = "${var.short_name}-worker-profile"
-  roles = ["${aws_iam_role.worker_role.name}"]
+  role = "${aws_iam_role.worker_role.name}"
 }
 
 resource "aws_iam_role_policy" "worker_policy" {


### PR DESCRIPTION
Fixed aws role(s) in the main of aws/iam/main.tf :: Only one role can be allocated not a list of roles

Hi, thank you for your contribution to Mantl! Before we can accept any code into
master, we need it to meet the following criteria. If there are any you can't
satisfy yourself, go ahead and open the pull request anyway and we'll help you
test. Feel free to delete this message once you're done. Thanks again!

- [y] Installs cleanly on a fresh build of most recent master branch
- [y] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
