### PR TITLE
[WIP] Update cni plugin configuration for calico v2.1

### DIFF
--- a/roles/calico/templates/calico-plugin.conf
+++ b/roles/calico/templates/calico-plugin.conf
@@ -3,6 +3,9 @@
     "type": "calico",
     "etcd_authority": "{{calico_etcdaddr}}",
     "log_level": "info",
+    "kubernetes": {
+        "k8s_api_root": "https://kubernetes.service.consul:{{ kube_master_port }}"
+    },
     "ipam": {
         "type": "calico-ipam"
     }


### PR DESCRIPTION
Include `k8s_api_root` option in cni plugin configuration. This will probably resolve all issues we currently have with kube2dns and k8s dashboard containers. 

Please do not merge until we double check it.