### PR TITLE
Remove obsoleted consul_dns_domain ansible var

### DIFF
--- a/etcd.yml
+++ b/etcd.yml
@@ -12,7 +12,6 @@
 
 - hosts: all
   vars:
-    consul_dns_domain: consul
     consul_servers_group: role=control
   roles:
     - common
@@ -43,14 +42,12 @@
 #- hosts: role=control
 #  gather_facts: no
 #  vars:
-#    consul_dns_domain: consul
 #    glusterfs_mode: server
 #  roles:
 #    - glusterfs
 #
 #- hosts: role=worker
 #  vars:
-#    consul_dns_domain: consul
 #    glusterfs_mode: client
 #  roles:
 #    - glusterfs

--- a/roles/vault/README.rst
+++ b/roles/vault/README.rst
@@ -34,7 +34,7 @@ Variables
 
    The default advertised address for vault, i.e. where Vault will listen.
 
-   default: ``vault_addr: "https://{{ inventory_hostname }}.node.{{ consul_dns_domain }}:{{ vault_default_port }}``
+   default: ``vault_addr: "https://{{ inventory_hostname }}.node.consul:{{ vault_default_port }}``
 
 .. data:: vault_init_json
 

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -3,7 +3,7 @@ vault_package: vault-0.6.0
 vault_default_port: 8200
 vault_command_options: -tls-skip-verify
 vault_config_file: /etc/vault/vault.hcl
-vault_addr: "https://{{ inventory_hostname }}.node.{{ consul_dns_domain }}:{{ vault_default_port }}"
+vault_addr: "https://{{ inventory_hostname }}.node.consul:{{ vault_default_port }}"
 
 vault_init_json: '{
 	"secret_shares": 5,


### PR DESCRIPTION
Current master is failing with the error below:

```
TASK: [vault | configure vault] *********************************************** 
fatal: [control-01] => {'msg': "AnsibleUndefinedVariable: One or more undefined variables: 'consul_dns_domain' is undefined", 'failed': True}
fatal: [control-01] => {'msg': "AnsibleUndefinedVariable: One or more undefined variables: 'consul_dns_domain' is undefined", 'failed': True}
```

Since mantl 1.2 the `consul_dns_domain` ansible var is no longer in use.