### PR TITLE
Fixes two ansible build issues

### DIFF
--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -1,7 +1,7 @@
 {% macro initial_cluster() -%}
 {% for host in groups['all'] -%}
 {% if hostvars[host]['inventory_hostname'] != 'localhost' -%}
-{{ hostvars[host]['inventory_hostname'] }}={{ etcd_peer_url_scheme }}://{{ hostvars[host]['inventory_hostname'] }}:{{ etcd_peer_port }},
+{{ hostvars[host]['inventory_hostname'] }}={{ etcd_url_scheme }}://{{ hostvars[host]['inventory_hostname'] }}:{{ etcd_peer_port }},
 {%- endif -%}
 {% endfor -%}
 {% endmacro -%}

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -3,7 +3,7 @@ vault_package: vault-0.6.0
 vault_default_port: 8200
 vault_command_options: -tls-skip-verify
 vault_config_file: /etc/vault/vault.hcl
-vault_addr: "https://{{ inventory_hostname }}.node.{{ consul_dns_domain }}:{{ vault_default_port }}"
+vault_addr: "https://{{ inventory_hostname }}.node.consul:{{ vault_default_port }}"
 
 vault_init_json: '{
 	"secret_shares": 5,


### PR DESCRIPTION
  - Use of etcd_peer_url_scheme should just be etcd_url_scheme
  - Removed usage of consul_dns_domain

- [y] Installs cleanly on a fresh build of most recent master branch
- [y] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
