### PR TITLE
First step in getting packer to work again.

### DIFF
--- a/packer/kickstarts/vagrant.cfg
+++ b/packer/kickstarts/vagrant.cfg
@@ -41,9 +41,9 @@ wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 
 # vagrant
 groupadd vagrant -g 999
-useradd vagrant -g vagrant -G wheel -u 900 -s /bin/bash
+useradd vagrant -g vagrant -G wheel -u 900 -s /bin/bash -d /home/vagrant -c "vagrant"
 
 # sudo
-echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
-sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers.d/vagrant
 %end

--- a/packer/scripts/vagrant.sh
+++ b/packer/scripts/vagrant.sh
@@ -1,11 +1,10 @@
 #!/bin/bash -eux
 
 # install the insecure public key for Vagrant
-mkdir -p /home/vagrant/.ssh
+mkdir -pm 700 /home/vagrant/.ssh
 curl https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub > /home/vagrant/.ssh/authorized_keys
 
 # make sure the permissions are correct for Vagrant to insert new keys on
 # `vagrant up`
 chown -R vagrant:vagrant /home/vagrant/.ssh
-chmod 0700 /home/vagrant/.ssh
 chmod 0600 /home/vagrant/.ssh/authorized_keys

--- a/packer/scripts/vbox.sh
+++ b/packer/scripts/vbox.sh
@@ -1,17 +1,7 @@
 #!/bin/bash -eux
-VBOXADDITIONS=/home/vagrant/VBoxGuestAdditions_4.3.26.iso
-
-# install dependencies
-yum install -y dkms bzip2
-
-# Mount the disk image
+VBOX_VERSION=$(cat /root/.vbox_version)
 cd /tmp
-mkdir /tmp/isomount
-mount -t iso9660 $VBOXADDITIONS /tmp/isomount
-
-# Install the drivers
-/tmp/isomount/VBoxLinuxAdditions.run
-
-# Cleanup
-umount isomount
-rm -rf isomount # $VBOXADDITIONS
+mount -o loop /root/VBoxGuestAdditions_$VBOX_VERSION.iso /mnt
+sh /mnt/VBoxLinuxAdditions.run
+umount /mnt
+rm -rf /home/vagrant/VBoxGuestAdditions_*.iso

--- a/packer/vagrant.json
+++ b/packer/vagrant.json
@@ -61,32 +61,7 @@
             "playbook_file": "{{user `root`}}/sample.yml",
             "staging_directory": "{{user `staging`}}",
             "extra_arguments": [ "--tags", "bootstrap", "--extra-vars=\"provider=vagrant\"" ],
-            "inventory_groups": "role=control,role=worker",
-            "role_paths": [
-                "roles/calico",
-                "roles/certificates",
-                "roles/common",
-                "roles/consul-template",
-                "roles/consul",
-                "roles/distributive",
-                "roles/dnsmasq",
-                "roles/docker",
-                "roles/etcd",
-                "roles/handlers",
-                "roles/kubernetes-master",
-                "roles/kubernetes-node",
-                "roles/kubernetes",
-                "roles/logrotate",
-                "roles/lvm",
-                "roles/mantlui",
-                "roles/marathon",
-                "roles/mesos",
-                "roles/nginx",
-                "roles/repos",
-                "roles/traefik",
-                "roles/vault",
-                "roles/zookeeper"
-            ]
+            "inventory_groups": "role=control,role=worker"
         },
         {
             "type": "shell",

--- a/packer/vagrant.json
+++ b/packer/vagrant.json
@@ -61,7 +61,32 @@
             "playbook_file": "{{user `root`}}/sample.yml",
             "staging_directory": "{{user `staging`}}",
             "extra_arguments": [ "--tags", "bootstrap", "--extra-vars=\"provider=vagrant\"" ],
-            "inventory_groups": "role=control,role=worker"
+            "inventory_groups": "role=control,role=worker",
+            "role_paths": [
+                "roles/calico",
+                "roles/certificates",
+                "roles/common",
+                "roles/consul-template",
+                "roles/consul",
+                "roles/distributive",
+                "roles/dnsmasq",
+                "roles/docker",
+                "roles/etcd",
+                "roles/handlers",
+                "roles/kubernetes-master",
+                "roles/kubernetes-node",
+                "roles/kubernetes",
+                "roles/logrotate",
+                "roles/lvm",
+                "roles/mantlui",
+                "roles/marathon",
+                "roles/mesos",
+                "roles/nginx",
+                "roles/repos",
+                "roles/traefik",
+                "roles/vault",
+                "roles/zookeeper"
+            ]
         },
         {
             "type": "shell",
@@ -81,11 +106,12 @@
             "headless": false,
             "http_directory": "{{template_dir}}/kickstarts",
             "iso_urls": [
-                "iso/CentOS-7-x86_64-Minimal-1511.iso",
-                "http://centos.mirrors.hoobly.com/7/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso"
+                "iso/CentOS-7-x86_64-Minimal-1611.iso",
+                "file:///Users/Shared/CentOS-7-x86_64-Minimal-1611.iso",
+                "http://centos.mirrors.hoobly.com/7/isos/x86_64/CentOS-7-x86_64-Minimal-1611.iso"
             ],
             "iso_checksum_type": "sha256",
-            "iso_checksum": "f90e4d28fa377669b2db16cbcb451fcb9a89d2460e3645993e30e137ac37d284",
+            "iso_checksum": "27bd866242ee058b7a5754e83d8ee8403e216b93d130d800852a96f41c34d86a",
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
             "ssh_port": 22,

--- a/vagrant/README.rst
+++ b/vagrant/README.rst
@@ -17,8 +17,8 @@ Getting Started
 Simply run ``vagrant up``. If you'd like to customize your build futher, you
 can create a vagrant-config.yml file in the project's root directory with
 variables as defined in the "Variables" section below.
-To mounta shared folder with any version of VirtualBox You need to install VBoxGuestAdditions.
-You also need to install a plugin to compile these at .vagrant up' time.
+To mount a shared folder with any version of VirtualBox you need to install VBoxGuestAdditions.
+You also need to install a plugin to compile these at `'vagrant up'` time.
 ``vagrant plugin install vagrant-vbguest``
 
 Variables

--- a/vagrant/README.rst
+++ b/vagrant/README.rst
@@ -17,6 +17,9 @@ Getting Started
 Simply run ``vagrant up``. If you'd like to customize your build futher, you
 can create a vagrant-config.yml file in the project's root directory with
 variables as defined in the "Variables" section below.
+To mounta shared folder with any version of VirtualBox You need to install VBoxGuestAdditions.
+You also need to install a plugin to compile these at .vagrant up' time.
+``vagrant plugin install vagrant-vbguest``
 
 Variables
 ---------


### PR DESCRIPTION
Issues resolved:
- ### Fix for #1399 "unknown filesystem type 'vboxsf'. 
    Cause: You were missing the (proper version of) the guest additions in the box.
    You need to install a plugin to install/upgrade these at .vagrant up' time.
    `vagrant plugin install vagrant-vbguest`

    **packer/scripts/vbox.sh** now mounts  the version of VBoxGuestAdditions that corresponds to your version of VirtualBox.
    Hardcoded version removed.


    Finally the guest can mount folders using this in the Vagrantfile:
    `config.vm.synced_folder ".", "/vagrant"`

- ### Fix for #1891 "Update Vagrant box"  Now 1611 Centos 7 iso
[Verify checksum against](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7#head-9e717f2e95c7cb447ef66c0a0ae1315027b67684)
`"27bd866242ee058b7a5754e83d8ee8403e216b93d130d800852a96f41c34d86a"`

### Improvements
- **packer/kickstarts/vagrant.cfg** creates a separate sudoers file for vagrant
- **packer/vagrant.json** l77-82 adds option to use a cached iso on OSX in /Users/Shared
- **packer/kickstarts/vagrant.cfg** adds info in /etc/passwd
- **packer/scripts/vagrant.sh** one line less.








